### PR TITLE
Adjust highlights based on original text to remove extra spaces

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -22,7 +22,7 @@ class Article(BaseModel):
     highlighted_abstract: bool = False
 
     @validator('highlights')
-    def highlights_(cls, v, values):
+    def validate_highlights(cls, v, values):
         if v:
             assert len(v) == len(values['paragraphs'])
         return v

--- a/api/app/routers/search.py
+++ b/api/app/routers/search.py
@@ -68,20 +68,15 @@ async def get_search(query: str):
         for result in ranked_results:
             paragraphs.extend(result.paragraphs)
         paragraphs = paragraphs[:settings.highlight_max_paragraphs]
+        all_highlights = highlighter.highlight_paragraphs(query=query, paragraphs=paragraphs)
 
-        new_paragraphs, all_highlights = highlighter.highlight_paragraphs(query=query, paragraphs=paragraphs)
-        highlighted_paragraphs = list(zip(new_paragraphs, all_highlights))
-
-        # Update ranked results with highlighted paragraphs.
+        # Update results with highlights.
         highlight_idx = 0
         for result in ranked_results:
             num_paragraphs = len(result.paragraphs)
-            highlighted = highlighted_paragraphs[highlight_idx:highlight_idx+num_paragraphs]
-            result.paragraphs = [h[0] for h in highlighted]
-            result.highlights = [h[1] for h in highlighted]
+            result.highlights = all_highlights[highlight_idx:highlight_idx+num_paragraphs]
             highlight_idx += num_paragraphs
-
-            if highlight_idx >= len(highlighted_paragraphs):
+            if highlight_idx >= len(all_highlights):
                 break
 
         print(f'Time to highlight: {time.time() - highlight_time}')

--- a/api/app/services/highlighter.py
+++ b/api/app/services/highlighter.py
@@ -128,20 +128,12 @@ class Highlighter:
         for kk in word_positions:
             para_words[kk] += self.highlight_token
 
-        tagged_paragraph = self.tokenizer.convert_tokens_to_string(
-            para_words)
-
-        # Clean up a list of simple English tokenization artifacts like spaces
-        # before punctuations and abreviated forms.
-        tagged_paragraph = self.tokenizer.clean_up_tokenization(
-            tagged_paragraph)
-
-        tagged_original_paragraph = self.adjust_highlights(original_paragraph,
-            tagged_paragraph)
+        tagged_paragraph = self.tokenizer.convert_tokens_to_string(para_words)
+        tagged_paragraph = self.adjust_highlights(original_paragraph, tagged_paragraph)
 
         tagged_sentences = [
             sent.string.strip()
-            for sent in self.nlp(tagged_original_paragraph).sents]
+            for sent in self.nlp(tagged_paragraph).sents]
 
         new_paragraph = []
         highlights = []

--- a/api/app/services/highlighter.py
+++ b/api/app/services/highlighter.py
@@ -68,8 +68,8 @@ class Highlighter:
                             para_words, original_paragraph) -> List[Tuple[int]]:
         '''Returns the start and end character positions of highlighted sentences'''
 
-        if original_paragraph is None or original_paragraph == "":
-            return '', []
+        if not original_paragraph:
+            return []
 
         sim_matrix = self.similarity_matrix(
             vector1=query_state, vector2=para_state)
@@ -116,8 +116,8 @@ class Highlighter:
         Iterates over highlighted and original text simultaneously to compute character positions.
         """
 
-        if len(highlights) == 0:
-            return original_text, []
+        if not highlights:
+            return []
 
         highlights_idx = 0
         original_text_idx = 0

--- a/api/app/services/highlighter.py
+++ b/api/app/services/highlighter.py
@@ -25,6 +25,7 @@ class Highlighter:
         self.nlp.add_pipe(self.nlp.create_pipe("sentencizer"))
 
         self.highlight_token = '[HIGHLIGHT]'
+        self.max_paragraph_length = 10000
 
     def text_to_vectors(self, text: str):
         """Converts a text to a sequence of vectors, one for each subword."""
@@ -133,7 +134,7 @@ class Highlighter:
 
         tagged_sentences = [
             sent.string.strip()
-            for sent in self.nlp(tagged_paragraph).sents]
+            for sent in self.nlp(tagged_paragraph[:self.max_paragraph_length]).sents]
 
         new_paragraph = []
         highlights = []


### PR DESCRIPTION
Fixes #13 

* Added a function to process highlighted text based on original text and adjust the highlight positions without extra spaces

* The algorithm is to greedily iterate using 2 pointers for both the original and highlighted text at the same time, where if characters are the same, then we can increment both pointers, otherwise if there is extra whitespace in one of the paragraphs, we increment the respective pointer

  * For example, if the highlighted text is "COVID - 19", and the original text is "COVID-19", then we iterate "C","C", -> "COVID","COVID" -> "COVID ","COVID" -> "COVID -", "COVID-"

  * This also handles the "[UNK]" token for characters that cannot be processed by the models

* Now we can just return the original paragraph directly!