### PR TITLE
Uses t5-base reranker finetuned on MS MARCO Med subset

### DIFF
--- a/api/.env.sample
+++ b/api/.env.sample
@@ -14,7 +14,7 @@ RM3_FB_DOCS=10
 RM3_ORIGINAL_QUERY_WEIGHT=0.5
 
 # T5 Parameters
-T5_MODEL_DIR=gs://neuralresearcher_data/covid/data/model_exp304
+T5_MODEL_DIR=gs://neuralresearcher_data/covid/data/model_exp377
 T5_BATCH_SIZE=96
 T5_DEVICE=cuda:0
 T5_MODEL_TYPE=t5-base

--- a/api/app/settings.py
+++ b/api/app/settings.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     rm3_original_query_weight: float = 0.5
 
     # T5 model settings
-    t5_model_dir: str = 'gs://neuralresearcher_data/covid/data/model_exp304'
+    t5_model_dir: str = 'gs://neuralresearcher_data/covid/data/model_exp377'
     t5_batch_size: int = 96
     t5_device: str = 'cuda:0'
     t5_model_type: str = 't5-base'


### PR DESCRIPTION
This model was finetuned on MS MARCO then fine-tuned (again) on the medical subset of MS MARCO (from https://arxiv.org/pdf/2005.02365.pdf).

We saw large gains on TREC-COVID (~7 points NDCG@10) by using this model as opposed to the one fine-tuned only on MS MARCO.

The checkpoint in gs://neuralresearcher_data/covid/data/model_exp377 corresponds to fine-tuning T5-base for 10K iterations (batch=128) on the full MS MARCO training set, which corresponds to 1 epoch, and then fine-tuning (again) for 1k iterations on the medical set of MS MARCO, which corresponds to 1 epoch.
